### PR TITLE
quick-patched a crash

### DIFF
--- a/LogisticsSigns/control.lua
+++ b/LogisticsSigns/control.lua
@@ -35,7 +35,7 @@ script.on_event(defines.events.on_preplayer_mined_item, function(event)
             if event.entity == global.signs[i].sign then
 
               for j = 1, #global.signs[i].objects do
-                global.signs[i].objects[j].destroy();
+                if global.signs[i].objects[j].valid then global.signs[i].objects[j].destroy(); end
               end
 
               table.remove(global.signs, i);

--- a/LogisticsSigns/control.lua
+++ b/LogisticsSigns/control.lua
@@ -29,8 +29,8 @@ script.on_event(defines.events.on_built_entity, function(event)
 end)
 
 -- Destroy text string when the sign is destroyed
-script.on_event(defines.events.on_preplayer_mined_item, function(event)
-    if event.entity.name == "util-sign" or event.entity.name == "util-sign-large" or  event.entity.name == "util-sign-small" then
+function on_destroyed(event)
+	if event.entity.name == "util-sign" or event.entity.name == "util-sign-large" or  event.entity.name == "util-sign-small" then
         for i = 1, #global.signs do
             if event.entity == global.signs[i].sign then
 
@@ -48,7 +48,11 @@ script.on_event(defines.events.on_preplayer_mined_item, function(event)
           gui = nil;
         end
     end
-end)
+end
+
+script.on_event(defines.events.on_preplayer_mined_item, on_destroyed)
+script.on_event(defines.events.on_robot_pre_mined, on_destroyed)
+script.on_event(defines.events.on_entity_died, on_destroyed)
 
 -- CREATE SIGNPOST GUI FOR WRITING TEXT
 function create_gui(player_index)
@@ -124,7 +128,10 @@ function create_sign_text(str, pos, parent)
           index = i - 1;
           offsetY = math.floor(index / lettersPerLine) * SPACING_VERTICAL - startingHeight;
           offsetX = index % lettersPerLine * SPACING_HORIZONTAL - startingWidth;
-          table.insert(strings, game.surfaces[1].create_entity{name = "ascii" .. string.byte(char), position =  {pos.x + offsetX, pos.y + offsetY}});
+		  
+		  local letter_entity = parent.surface.create_entity{name = "ascii" .. string.byte(char), position = {pos.x + offsetX, pos.y + offsetY}};
+		  letter_entity.destructible = false;
+          table.insert(strings, letter_entity);
     end
       table.insert(global.signs, {sign = parent, objects = strings});
   end
@@ -136,7 +143,9 @@ end
  --parent: the entity that owns this icon
 function create_sign_icon(icon, pos, parent)
    offsetX = 0;
-   offsetY = 0.75;
-   icon_entity = game.surfaces[1].create_entity{ name = icon, position = {pos.x - offsetX, pos.y - offsetY} };
+   offsetY = 0.8;
+   
+   icon_entity = parent.surface.create_entity{ name = icon, position = {pos.x - offsetX, pos.y - offsetY} };
+   icon_entity.destructible = false;
    table.insert(global.signs, {sign = parent, objects = {icon_entity}});
 end

--- a/LogisticsSigns/prototypes/entities.lua
+++ b/LogisticsSigns/prototypes/entities.lua
@@ -3,7 +3,7 @@ require("config")
 sign_entities = {}
 
 sign_entity = {
-    type = "decorative",
+    type = "simple-entity",
     name = "util-sign",
     icon = "__LogisticsSigns__/graphics/icons/sign-icon.png",
     flags = {"placeable-neutral"},
@@ -31,7 +31,7 @@ sign_entity = {
 table.insert(sign_entities, sign_entity)
 
 sign_large_metal_entity = {
-    type = "decorative",
+    type = "simple-entity",
     name = "util-sign-large",
     icon = "__LogisticsSigns__/graphics/icons/sign-large-metal-icon.png",
     flags = {"placeable-neutral"},
@@ -60,7 +60,7 @@ sign_large_metal_entity = {
 table.insert(sign_entities, sign_large_metal_entity)
 
 sign_small_entity = {
-   type = "decorative",
+   type = "simple-entity",
    name = "util-sign-small",
    icon = "__LogisticsSigns__/graphics/icons/sign-small-icon.png",
    flags = {"placeable-neutral"},
@@ -90,10 +90,12 @@ table.insert(sign_entities, sign_small_entity)
 for i = FIRSTASCII, LASTASCII do
 
 	letter = {
-		type = "decorative",
+		type = "simple-entity",
 		name = "ascii" .. i,
 		flags = {"placeable-off-grid", "not-on-map"},
+		collision_mask = {},
 		selectable_in_game = false,
+		max_health = 1000,
 		render_layer = "higher-object-above",
 		pictures =
 		{
@@ -115,17 +117,20 @@ for i, icon in pairs(ICONS) do
   for _, object in pairs(data.raw[icon]) do
 
     notice_icon = {
-        type = "decorative",
+        type = "simple-entity",
         name = "icon-notice-" .. object.name,
         flags = {"placeable-off-grid", "not-on-map"},
+		collision_mask = {},
         selectable_in_game = false,
         render_layer = "higher-object-above",
+		max_health = 1000,
         pictures =
         {
           filename = object.icon,
           priority = "medium",
           width = 32,
-          height = 32
+          height = 32,
+		  scale = 0.8,
         }
     }
 


### PR DESCRIPTION
When some tiles are placed at the signs position, the letters get
removed by the game since they are decorative. Then when the sign was
mined the mod would crash.
Some better solution like replacing the letters when they're destroyed
would be nice.